### PR TITLE
Revamped CLion tutorial because of license change

### DIFF
--- a/src/prostredi/editor/clion.md
+++ b/src/prostredi/editor/clion.md
@@ -3,19 +3,6 @@
 Nejlepší způsob instalace je použití aplikace [Toolbox](https://www.jetbrains.com/toolbox-app/), která vám umožní spravovat všechna vaše IDE od JetBrains. Pokud narazíte na problém, kompletní návod
 naleznete [zde](https://www.jetbrains.com/help/clion/installation-guide.html#toolbox).
 
-## Licence
-
-CLion nabízí 30denní zkušební verzi (trial) pro vyzkoušení. Pokud chcete CLion používat po této době, můžete požádat o [školní licenci](https://www.jetbrains.com/shop/eform/students).
-
-- Na stránce jsou čtyři způsoby, jak licenci získat. Nejjednodušší je použít váš školní e-mail. Email je v následujícím tvaru: ```<login>@vsb.cz```, např. ```UPR0123@vsb.cz```
-- Po vyplnění dotazníku vám přijde potvrzovací e-mail o schválení **Educational Packu**. Otevřete odkaz v e-mailu a potvrďte podmínky. Poté si vytvořte účet s vaším školním
-  e-mailem [zde](https://account.jetbrains.com/login).
-- Stav vaší licence můžete zkontrolovat [zde](https://account.jetbrains.com/licenses). Zde také uvidíte všechny produkty, na které se licence vztahuje.
-
-- Nakonec se stačí v **Toolboxu** přihlásit pod účtem, který jste si vytvořili.
-
-  <img src="../../static/video/toolbox_login.gif" width="288" height="409" >
-
 ## První projekt
 
 Po spuštění CLionu klikněte na `New Project` a vyberte `C Executable`. Nastavte umístění projektu a můžete také zvolit standard jazyka C, který lze později změnit i v CMaku. Program spustíte pomocí
@@ -46,8 +33,21 @@ V souboru CMakeLists.txt nastavíme starší verzi CMaku na verzi 3.21
 cmake_minimum_required(VERSION 3.21)
 ```
 
->Pokaždé, když v CMaku uděláme změnu je potřeba soubor znovu načíst. Buď si zapnete auto-reload pomocí příkazu ```Auto-Reload CMake Project``` nebo kliknete na soubor pravým a dáte ```Reload CMake Project```
+> Pokaždé, když v CMaku uděláme změnu je potřeba soubor znovu načíst. Buď si zapnete auto-reload pomocí příkazu `Auto-Reload CMake Project` nebo kliknete na soubor pravým a dáte `Reload CMake Project`
 
 Pokud chcete pochopit fungování CMaku, tak můžete [zde](../../c/automatizace_prekladu.md#cmake).
 
 Jak naimportovat SDL pro následující projekt můžete najít [zde](../../c/aplikovane_ulohy/sdl.md#přilinkování-knihovny-sdl).
+
+## Licence Education Pack na jíne produkty JetBrains
+
+JetBrains má spoustu jiných produktů na vývoj, ladění, práci s databázemi atd. Část z nich potřebuje pro používání licenci, o kterou můžete jako studenti požádat zdarma [zde](https://www.jetbrains.com/shop/eform/students).
+
+- Na stránce jsou čtyři způsoby, jak licenci získat. Nejjednodušší je použít váš školní e-mail. Email je v následujícím tvaru: `<login>@vsb.cz`, např. `UPR0123@vsb.cz`
+- Po vyplnění dotazníku vám přijde potvrzovací e-mail o schválení **Educational Packu**. Otevřete odkaz v e-mailu a potvrďte podmínky. Poté si vytvořte účet s vaším školním
+  e-mailem [zde](https://account.jetbrains.com/login).
+- Stav vaší licence můžete zkontrolovat [zde](https://account.jetbrains.com/licenses). Zde také uvidíte všechny produkty, na které se licence vztahuje.
+
+- Nakonec se stačí v **Toolboxu** přihlásit pod účtem, který jste si vytvořili.
+
+<img src="../../static/video/toolbox_login.gif" width="288" height="409" >


### PR DESCRIPTION
Revamped CLion tutorial because of license change. CLion is now ['Free for non-commercial use'](https://www.jetbrains.com/clion/), so current instructions are a bit confusing. I placed the "Licence" paragraph at the very end, and emphasize, that it's not required to use CLion but you can use it for other paid JetBrains projects.